### PR TITLE
Crypto pkg v0.0.3, Models pkg v0.0.4

### DIFF
--- a/apps/api/internal/handlers/objects.go
+++ b/apps/api/internal/handlers/objects.go
@@ -44,7 +44,7 @@ func (h *ObjectHandler) Create(c *gin.Context) {
 	objectId := uuid.NewString()
 	s3Key := generateS3Key(tenantId, objectId, 1)
 
-	obj := models.NewObject(tenantId, objectId, s3Key, req.EncryptedDEK)
+	obj := models.NewObject(tenantId, objectId, s3Key, req.EncryptedDEK, req.EncryptedSchemaName)
 	if req.Sensitivity != "" {
 		obj.Sensitivity = req.Sensitivity
 	} else {
@@ -99,12 +99,13 @@ func (h *ObjectHandler) Get(c *gin.Context) {
 	}
 
 	resp := models.GetObjectResponse{
-		ObjectID:     id,
-		EncryptedDEK: obj.EncryptedDEK,
-		GetURL:       getUrl,
-		CreatedAt:    obj.CreatedAt,
-		UpdatedAt:    obj.UpdatedAt,
-		Version:      obj.Version,
+		ObjectID:            id,
+		EncryptedDEK:        obj.EncryptedDEK,
+		EncryptedSchemaName: obj.EncryptedSchemaName,
+		GetURL:              getUrl,
+		CreatedAt:           obj.CreatedAt,
+		UpdatedAt:           obj.UpdatedAt,
+		Version:             obj.Version,
 	}
 
 	c.JSON(http.StatusOK, resp)

--- a/pkg/crypto/kms.go
+++ b/pkg/crypto/kms.go
@@ -125,8 +125,10 @@ func InitEnclaveSecureSession(ctx context.Context, config SessionConfig) (*Encla
 
 	if _, err := ess.verifyAttestation(config); err != nil {
 		zero(ess.SessionKey)
-		return nil, fmt.Errorf("attestation verification failed: %w", err)
+		return ess, fmt.Errorf("attestation verification failed: %w", err)
 	}
+
+	ess.AttestationVerified = true
 
 	return ess, nil
 }

--- a/pkg/models/object.go
+++ b/pkg/models/object.go
@@ -9,9 +9,10 @@ type Object struct {
 	PK string `dynamodbav:"pk" json:"pk"` // format: "TENANT#<tenant_id>"
 	SK string `dynamodbav:"sk" json:"sk"` // format: "OBJ#<object_id>"
 
-	S3Key        string `dynamodbav:"s3_key,omitempty" json:"s3_key,omitempty"`
-	EncryptedDEK string `dynamodbav:"encrypted_dek,omitempty" json:"encrypted_dek,omitempty"`
-	Sensitivity  string `dynamodbav:"sensitivity,omitempty" json:"sensitivity,omitempty"`
+	S3Key               string `dynamodbav:"s3_key,omitempty" json:"s3_key,omitempty"`
+	EncryptedDEK        string `dynamodbav:"encrypted_dek,omitempty" json:"encrypted_dek,omitempty"`
+	EncryptedSchemaName string `dynamodbav:"encrypted_schema,omitempty" json:"encrypted_schema,omitempty"`
+	Sensitivity         string `dynamodbav:"sensitivity,omitempty" json:"sensitivity,omitempty"`
 
 	CreatedAt time.Time `dynamodbav:"created_at,omitempty" json:"created_at,omitempty"`
 	UpdatedAt time.Time `dynamodbav:"updated_at,omitempty" json:"updated_at,omitempty"`
@@ -32,23 +33,25 @@ const (
 	SensitivityHigh   = "high"
 )
 
-func NewObject(tenantId string, objectId string, s3Key string, encryptedDek string) *Object {
+func NewObject(tenantId string, objectId string, s3Key string, encryptedDek string, encryptedSchemaName string) *Object {
 	return &Object{
-		PK:           fmt.Sprintf("TENANT#%s", tenantId),
-		SK:           fmt.Sprintf("OBJ#%s", objectId),
-		S3Key:        s3Key,
-		EncryptedDEK: encryptedDek,
-		Status:       StatusPending,
-		CreatedAt:    time.Now().UTC(),
-		UpdatedAt:    time.Now().UTC(),
-		Version:      1,
+		PK:                  fmt.Sprintf("TENANT#%s", tenantId),
+		SK:                  fmt.Sprintf("OBJ#%s", objectId),
+		S3Key:               s3Key,
+		EncryptedDEK:        encryptedDek,
+		EncryptedSchemaName: encryptedSchemaName,
+		Status:              StatusPending,
+		CreatedAt:           time.Now().UTC(),
+		UpdatedAt:           time.Now().UTC(),
+		Version:             1,
 	}
 }
 
 type CreateObjectRequest struct {
-	EncryptedDEK string            `json:"encrypted_dek" binding:"required"`
-	Indexes      map[string]string `json:"indexes,omitempty"`
-	Sensitivity  string            `json:"sensitivity,omitempty" binding:"omitempty,oneof=low medium high"`
+	EncryptedDEK        string            `json:"encrypted_dek" binding:"required"`
+	EncryptedSchemaName string            `json:"encrypted_schema" binding:"required"`
+	Indexes             map[string]string `json:"indexes,omitempty"`
+	Sensitivity         string            `json:"sensitivity,omitempty" binding:"omitempty,oneof=low medium high"`
 }
 
 type CreateObjectResponse struct {
@@ -59,10 +62,11 @@ type CreateObjectResponse struct {
 }
 
 type GetObjectResponse struct {
-	ObjectID     string    `json:"object_id"`
-	GetURL       string    `json:"get_url"`
-	EncryptedDEK string    `json:"encrypted_dek"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
-	Version      int32     `json:"version"`
+	ObjectID            string    `json:"object_id"`
+	GetURL              string    `json:"get_url"`
+	EncryptedDEK        string    `json:"encrypted_dek"`
+	EncryptedSchemaName string    `json:"encrypted_schema"`
+	CreatedAt           time.Time `json:"created_at"`
+	UpdatedAt           time.Time `json:"updated_at"`
+	Version             int32     `json:"version"`
 }


### PR DESCRIPTION
This pull request adds support for handling an encrypted schema name for objects throughout the API and data models. It ensures that the `EncryptedSchemaName` field is captured in requests, stored in the database, and returned in responses. Additionally, there is a minor fix in the enclave secure session initialization to improve error handling and state consistency.

**Encrypted schema name support:**

* Added `EncryptedSchemaName` as a field to the `Object` model and updated the `NewObject` constructor to accept and set this value (`pkg/models/object.go`).

**Enclave secure session initialization:**

* Fixed the `InitEnclaveSecureSession` function to return the partially constructed session object on attestation verification failure and explicitly set the `AttestationVerified` flag on success (`pkg/crypto/kms.go`).