### PR TITLE
Support DynamoDB inline blob upload for small objects, API pkg v0.0.3, models pkg v0.0.7, crypto pkg v0.0.8

### DIFF
--- a/apps/api/cmd/server/main.go
+++ b/apps/api/cmd/server/main.go
@@ -124,6 +124,7 @@ func (s *Server) setupRoutes(s3Client *storage.S3Client, dynamoClient *storage.D
 	objects.POST("/table-hash", objectHandler.GetTableHash)
 	objects.GET("/:table-hash/:id", objectHandler.Get)
 	objects.POST("/:table-hash", objectHandler.Create)
+	objects.PUT("/:table-hash/:id/upload-inline", objectHandler.UploadInline)
 
 	encryptionHandler := &handlers.EncryptionHandler{
 		Vsock:  vsock,

--- a/apps/api/internal/handlers/objects.go
+++ b/apps/api/internal/handlers/objects.go
@@ -59,10 +59,6 @@ func (h *ObjectHandler) GetTableHash(c *gin.Context) {
 		SessionTableNameNonce:     req.SessionTableNameNonce,
 		TableSalt:                 base64.StdEncoding.EncodeToString(tableSalt.CiphertextForRecipient),
 	}
-	if err := c.BindJSON(&enclaveReqBody); err != nil {
-		c.JSON(400, gin.H{"error": fmt.Sprintf("Invalid session init request: %v", err)})
-		return
-	}
 	payloadBytes, err := json.Marshal(enclaveReqBody)
 	if err != nil {
 		c.JSON(500, gin.H{"error": fmt.Sprintf("Failed to marshal session init request: %v", err)})

--- a/apps/api/internal/storage/dynamo.go
+++ b/apps/api/internal/storage/dynamo.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	ddbTypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -56,7 +56,7 @@ func (d *DynamoClient) CreateObjectWithIndexes(ctx context.Context, tableHash st
 		return err
 	}
 
-	indexItems := make([]map[string]ddbtypes.AttributeValue, 0, len(indexes))
+	indexItems := make([]map[string]ddbTypes.AttributeValue, 0, len(indexes))
 	for idxName, token := range indexes {
 		index := models.NewIndex(idxName, extractTenantFromPK(obj.PK), tableHash, token, extractObjectIdFromSK(obj.SK), obj.S3Key)
 		av, err := attributevalue.MarshalMap(index)
@@ -68,11 +68,11 @@ func (d *DynamoClient) CreateObjectWithIndexes(ctx context.Context, tableHash st
 
 	// if total items to put is <= 25, use a single transact write
 	if len(indexItems) <= 25 {
-		twrite := make([]ddbtypes.TransactWriteItem, 0, len(indexItems)+1)
+		twrite := make([]ddbTypes.TransactWriteItem, 0, len(indexItems)+1)
 
 		// obj put
-		twrite = append(twrite, ddbtypes.TransactWriteItem{
-			Put: &ddbtypes.Put{
+		twrite = append(twrite, ddbTypes.TransactWriteItem{
+			Put: &ddbTypes.Put{
 				TableName: aws.String(d.ObjectsTable),
 				Item:      objMap,
 			},
@@ -80,8 +80,8 @@ func (d *DynamoClient) CreateObjectWithIndexes(ctx context.Context, tableHash st
 
 		// indexes puts
 		for _, item := range indexItems {
-			twrite = append(twrite, ddbtypes.TransactWriteItem{
-				Put: &ddbtypes.Put{
+			twrite = append(twrite, ddbTypes.TransactWriteItem{
+				Put: &ddbTypes.Put{
 					TableName: aws.String(d.IndexesTable),
 					Item:      item,
 				},
@@ -106,17 +106,17 @@ func (d *DynamoClient) CreateObjectWithIndexes(ctx context.Context, tableHash st
 	for i := 0; i < len(indexItems); i += batchSize {
 		end := min(i+batchSize, len(indexItems))
 
-		writeRequests := make([]ddbtypes.WriteRequest, 0, end-i)
+		writeRequests := make([]ddbTypes.WriteRequest, 0, end-i)
 		for _, item := range indexItems[i:end] {
-			writeRequests = append(writeRequests, ddbtypes.WriteRequest{
-				PutRequest: &ddbtypes.PutRequest{
+			writeRequests = append(writeRequests, ddbTypes.WriteRequest{
+				PutRequest: &ddbTypes.PutRequest{
 					Item: item,
 				},
 			})
 		}
 
 		_, err = d.Client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
-			RequestItems: map[string][]ddbtypes.WriteRequest{
+			RequestItems: map[string][]ddbTypes.WriteRequest{
 				d.IndexesTable: writeRequests,
 			},
 		})
@@ -128,6 +128,27 @@ func (d *DynamoClient) CreateObjectWithIndexes(ctx context.Context, tableHash st
 	return nil
 }
 
+func (d *DynamoClient) UpdateObjectInlineBlob(ctx context.Context, tenantId string, tableHash string, objectId string, inlineBlob string) error {
+	_, err := d.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(d.ObjectsTable),
+		Key: map[string]ddbTypes.AttributeValue{
+			"pk": &ddbTypes.AttributeValueMemberS{Value: "TENANT#" + tenantId + "#TABLE#" + tableHash},
+			"sk": &ddbTypes.AttributeValueMemberS{Value: "OBJ#" + objectId},
+		},
+		UpdateExpression: aws.String("SET #status = :ready, #blob = :blob REMOVE #ttl"),
+		ExpressionAttributeNames: map[string]string{
+			"#status": "status",
+			"#ttl":    "TTL",
+			"#blob":   "encrypted_blob",
+		},
+		ExpressionAttributeValues: map[string]ddbTypes.AttributeValue{
+			":ready": &ddbTypes.AttributeValueMemberS{Value: models.StatusReady},
+			":blob":  &ddbTypes.AttributeValueMemberS{Value: inlineBlob},
+		},
+	})
+	return err
+}
+
 /*
 GetObject retrieves an object by tenant ID and object ID from DynamoDB.
 */
@@ -137,9 +158,9 @@ func (d *DynamoClient) GetObject(ctx context.Context, tenantId string, tableHash
 
 	out, err := d.Client.GetItem(ctx, &dynamodb.GetItemInput{
 		TableName: &d.ObjectsTable,
-		Key: map[string]ddbtypes.AttributeValue{
-			"pk": &ddbtypes.AttributeValueMemberS{Value: pk},
-			"sk": &ddbtypes.AttributeValueMemberS{Value: sk},
+		Key: map[string]ddbTypes.AttributeValue{
+			"pk": &ddbTypes.AttributeValueMemberS{Value: pk},
+			"sk": &ddbTypes.AttributeValueMemberS{Value: sk},
 		},
 	})
 
@@ -162,18 +183,18 @@ func (d *DynamoClient) BatchGetEncryptedDEKs(ctx context.Context, tenantId strin
 	if len(objectsIds) == 0 {
 		return map[string]string{}, nil
 	}
-	keys := make([]map[string]ddbtypes.AttributeValue, 0, len(objectsIds))
+	keys := make([]map[string]ddbTypes.AttributeValue, 0, len(objectsIds))
 	for _, objectId := range objectsIds {
 		pk := fmt.Sprintf("TENANT#%s#TABLE#%s", tenantId, tableHash)
 		sk := fmt.Sprintf("OBJ#%s", objectId)
-		keys = append(keys, map[string]ddbtypes.AttributeValue{
-			"pk": &ddbtypes.AttributeValueMemberS{Value: pk},
-			"sk": &ddbtypes.AttributeValueMemberS{Value: sk},
+		keys = append(keys, map[string]ddbTypes.AttributeValue{
+			"pk": &ddbTypes.AttributeValueMemberS{Value: pk},
+			"sk": &ddbTypes.AttributeValueMemberS{Value: sk},
 		})
 	}
 
 	out, err := d.Client.BatchGetItem(ctx, &dynamodb.BatchGetItemInput{
-		RequestItems: map[string]ddbtypes.KeysAndAttributes{
+		RequestItems: map[string]ddbTypes.KeysAndAttributes{
 			d.ObjectsTable: {
 				Keys:                 keys,
 				ProjectionExpression: aws.String("sk, kms_wrapped_dek"),
@@ -215,8 +236,8 @@ func (d *DynamoClient) GetTenant(ctx context.Context, tenantID string) (*models.
 
 	out, err := d.Client.GetItem(ctx, &dynamodb.GetItemInput{
 		TableName: aws.String(d.TenantConfigTable),
-		Key: map[string]ddbtypes.AttributeValue{
-			"pk": &ddbtypes.AttributeValueMemberS{Value: pk},
+		Key: map[string]ddbTypes.AttributeValue{
+			"pk": &ddbTypes.AttributeValueMemberS{Value: pk},
 		},
 	})
 	if err != nil {
@@ -254,11 +275,11 @@ func (d *DynamoClient) FindAPIKey(ctx context.Context, tenantID string, provided
 	pk := fmt.Sprintf("TENANT#%s", tenantID)
 	out, err := d.Client.Query(ctx, &dynamodb.QueryInput{
 		TableName: aws.String(d.APIKeysTable),
-		KeyConditions: map[string]ddbtypes.Condition{
+		KeyConditions: map[string]ddbTypes.Condition{
 			"pk": {
-				ComparisonOperator: ddbtypes.ComparisonOperatorEq,
-				AttributeValueList: []ddbtypes.AttributeValue{
-					&ddbtypes.AttributeValueMemberS{Value: pk},
+				ComparisonOperator: ddbTypes.ComparisonOperatorEq,
+				AttributeValueList: []ddbTypes.AttributeValue{
+					&ddbTypes.AttributeValueMemberS{Value: pk},
 				},
 			},
 		},

--- a/apps/api/internal/storage/dynamo.go
+++ b/apps/api/internal/storage/dynamo.go
@@ -214,7 +214,7 @@ func (d *DynamoClient) GetTenant(ctx context.Context, tenantID string) (*models.
 	pk := fmt.Sprintf("TENANT#%s", tenantID)
 
 	out, err := d.Client.GetItem(ctx, &dynamodb.GetItemInput{
-		TableName: &d.TenantConfigTable,
+		TableName: aws.String(d.TenantConfigTable),
 		Key: map[string]ddbtypes.AttributeValue{
 			"pk": &ddbtypes.AttributeValueMemberS{Value: pk},
 		},
@@ -244,7 +244,7 @@ func (d *DynamoClient) CreateAPIKey(ctx context.Context, tenantID string) (strin
 		return "", err
 	}
 	_, err = d.Client.PutItem(ctx, &dynamodb.PutItemInput{
-		TableName: aws.String(d.TenantConfigTable),
+		TableName: aws.String(d.APIKeysTable),
 		Item:      item,
 	})
 	return apiKey, err

--- a/apps/enclave-service/internal/utils/hash.go
+++ b/apps/enclave-service/internal/utils/hash.go
@@ -1,8 +1,13 @@
 package utils
 
-import "golang.org/x/crypto/bcrypt"
+import (
+	"crypto/sha256"
+	"encoding/base64"
+)
 
 func Hash(data []byte, salt []byte) string {
-	hashedData, _ := bcrypt.GenerateFromPassword(append(data, salt...), bcrypt.DefaultCost)
-	return string(hashedData)
+	h := sha256.New()
+	h.Write(data)
+	h.Write(salt)
+	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
 }

--- a/pkg/api/objects/requests.go
+++ b/pkg/api/objects/requests.go
@@ -7,9 +7,16 @@ type GetTableHashRequest struct {
 }
 
 type CreateObjectRequest struct {
+	BlobSize           int64             `json:"blob_size" binding:"required"`
 	KMSEncryptedDEK    string            `json:"encrypted_dek" binding:"required"`
 	MasterEncryptedDEK string            `json:"master_encrypted_dek" binding:"required"`
 	DEKNonce           string            `json:"dek_nonce" binding:"required"`
 	Indexes            map[string]string `json:"indexes,omitempty"`
 	Sensitivity        string            `json:"sensitivity,omitempty" binding:"omitempty,oneof=low medium high"`
+}
+
+type ScanRequest struct {
+	TableHash string  `json:"table_hash" binding:"required"`
+	Limit     int     `json:"limit,omitempty"`
+	NextToken *string `json:"next_token,omitempty"`
 }

--- a/pkg/api/objects/responses.go
+++ b/pkg/api/objects/responses.go
@@ -14,13 +14,20 @@ type CreateObjectResponse struct {
 	TableHash string    `json:"table_hash"`
 }
 
-type GetObjectResponse struct {
+type ResultObject struct {
 	ObjectID         string    `json:"object_id"`
 	GetURL           string    `json:"get_url"`
+	EncryptedBlob    string    `json:"encrypted_blob,omitempty"`
 	KMSWrappedDEK    string    `json:"kms_wrapped_dek,omitempty"`
 	MasterWrappedDEK string    `json:"master_wrapped_dek,omitempty"`
 	DEKNonce         string    `json:"dek_nonce,omitempty"`
 	CreatedAt        time.Time `json:"created_at"`
 	UpdatedAt        time.Time `json:"updated_at"`
 	Version          int32     `json:"version"`
+}
+
+type GetObjectResponse = ResultObject
+
+type ScanResponse struct {
+	Objects []ResultObject `json:"objects"`
 }

--- a/pkg/crypto/kms_test.go
+++ b/pkg/crypto/kms_test.go
@@ -1,10 +1,7 @@
 package crypto
 
 import (
-	"bytes"
 	"context"
-	"crypto/rand"
-	"encoding/base64"
 	"flag"
 	"os"
 	"testing"
@@ -52,28 +49,4 @@ func TestGenerateDEK(t *testing.T) {
 		t.Fatalf("Expected 3 DEKs, got %d", len(DEKs))
 	}
 	t.Logf("Successfully generated DEKs")
-}
-
-func TestUnwrapSingleDEK(t *testing.T) {
-	ctx := context.Background()
-	sess, err := InitEnclaveSecureSession(ctx, config)
-	if err != nil {
-		t.Fatalf("Failed to start decrypt session: %v", err)
-	}
-	DEKs, err := sess.GenerateDEK(ctx, 1)
-	if err != nil {
-		t.Fatalf("Failed to generate DEK: %v", err)
-	}
-	nonce := make([]byte, 32)
-	if _, err := rand.Read(nonce); err != nil {
-		t.Fatalf("Failed to generate nonce: %v", err)
-	}
-	unwrappedDEK, err := UnwrapSingleDEK(ctx, config.Endpoint, base64.StdEncoding.EncodeToString(DEKs[0].KMSEncryptedDEK), base64.StdEncoding.EncodeToString(nonce))
-	if err != nil {
-		t.Fatalf("Failed to unwrap DEK: %v", err)
-	}
-	if !bytes.Equal(DEKs[0].PlaintextDEK, unwrappedDEK) {
-		t.Fatalf("Unwrapped DEK does not match original DEK")
-	}
-	t.Logf("Successfully unwrapped DEK")
 }

--- a/pkg/models/index.go
+++ b/pkg/models/index.go
@@ -9,7 +9,7 @@ type Index struct {
 	PK string `dynamodbav:"pk" json:"pk"` // format: "TENANT#<tenant_id>#TABLE#<table_hash>#IDX#<index_name>"
 	SK string `dynamodbav:"sk" json:"sk"` // format: "TOKEN#<index_token>#OBJ#<object_id>"
 
-	S3Key     string    `dynamodbav:"s3_key,omitempty" json:"s3_key,omitempty"` // Duplicated S3 key for quick access
+	S3Key     string    `dynamodbav:"s3_key,omitempty" json:"s3_key,omitempty"` // Duplicated S3 key for quick access (larger blobs)
 	CreatedAt time.Time `dynamodbav:"created_at,omitempty" json:"created_at"`
 }
 

--- a/pkg/models/object.go
+++ b/pkg/models/object.go
@@ -9,7 +9,8 @@ type Object struct {
 	PK string `dynamodbav:"pk" json:"pk"` // format: "TENANT#<tenant_id>#TABLE#<table_hash>"
 	SK string `dynamodbav:"sk" json:"sk"` // format: "OBJ#<object_id>"
 
-	S3Key string `dynamodbav:"s3_key,omitempty" json:"s3_key,omitempty"`
+	EncryptedBlob string `dynamodbav:"encrypted_blob,omitempty" json:"encrypted_blob,omitempty"` // < 100KB blobs stored inline
+	S3Key         string `dynamodbav:"s3_key,omitempty" json:"s3_key,omitempty"`                 // S3 object key for larger blobs
 
 	KMSWrappedDEK    string `dynamodbav:"kms_wrapped_dek,omitempty" json:"kms_wrapped_dek,omitempty"`       // DEK wrapped with KMS
 	MasterWrappedDEK string `dynamodbav:"master_wrapped_dek,omitempty" json:"master_wrapped_dek,omitempty"` // DEK wrapped with tenant master key
@@ -36,11 +37,10 @@ const (
 	SensitivityHigh   = "high"
 )
 
-func NewObject(tenantId string, tableHash string, objectId string, s3Key string, kmsWrappedDEK string, masterWrappedDEK string, dekNonce string) *Object {
+func NewObject(tenantId string, tableHash string, objectId string, kmsWrappedDEK string, masterWrappedDEK string, dekNonce string) *Object {
 	return &Object{
 		PK:               fmt.Sprintf("TENANT#%s#TABLE#%s", tenantId, tableHash),
 		SK:               fmt.Sprintf("OBJ#%s", objectId),
-		S3Key:            s3Key,
 		KMSWrappedDEK:    kmsWrappedDEK,
 		MasterWrappedDEK: masterWrappedDEK,
 		DEKNonce:         dekNonce,


### PR DESCRIPTION
This pull request introduces support for inline blob storage for small objects (≤100KB) in addition to existing S3-based storage for larger objects. It adds a new API endpoint for uploading inline blobs, updates the object creation logic to select the appropriate storage method based on blob size, and refactors several DynamoDB operations to support this functionality. Additionally, it improves tenant authentication for enclave sessions and standardizes DynamoDB type usage.

**Inline Blob Storage and API Enhancements**
* Added a new `PUT /objects/:table-hash/:id/upload-inline` endpoint for uploading small blobs directly to DynamoDB, and implemented the corresponding handler `UploadInline` in `ObjectHandler`. [[1]](diffhunk://#diff-989ea5710a6a51af49dd6af2f93e82036856f7b9cceadc33c86b997920294895R127) [[2]](diffhunk://#diff-64fe0d64996ab921818dabbdbf5dc0212e5ed6d8fc7b3d968740f7aef32efc1aR156-R192)
* Updated object creation logic: objects with blobs ≤100KB are set up for inline storage and receive an upload URL pointing to the new endpoint, while larger objects continue to use S3 and presigned URLs.
* Modified object retrieval to return either a presigned S3 URL or the inline encrypted blob, depending on the storage method. Also, objects must be in READY status to be retrieved.

**DynamoDB Client Refactoring**
* Standardized DynamoDB type usage by renaming imports and updating all references from `ddbtypes` to `ddbTypes`. [[1]](diffhunk://#diff-550cd3c22e36952ec37b615b2ee3b46cf1370227069aeeaa3298301282851f21L12-R12) [[2]](diffhunk://#diff-550cd3c22e36952ec37b615b2ee3b46cf1370227069aeeaa3298301282851f21L59-R59) [[3]](diffhunk://#diff-550cd3c22e36952ec37b615b2ee3b46cf1370227069aeeaa3298301282851f21L71-R84) [[4]](diffhunk://#diff-550cd3c22e36952ec37b615b2ee3b46cf1370227069aeeaa3298301282851f21L109-R119) [[5]](diffhunk://#diff-550cd3c22e36952ec37b615b2ee3b46cf1370227069aeeaa3298301282851f21L140-R163) [[6]](diffhunk://#diff-550cd3c22e36952ec37b615b2ee3b46cf1370227069aeeaa3298301282851f21L165-R197) [[7]](diffhunk://#diff-550cd3c22e36952ec37b615b2ee3b46cf1370227069aeeaa3298301282851f21L217-R240) [[8]](diffhunk://#diff-550cd3c22e36952ec37b615b2ee3b46cf1370227069aeeaa3298301282851f21L257-R282)
* Added `UpdateObjectInlineBlob` to update inline blob data and set object status to READY in DynamoDB.

**Authentication and API Key Improvements**
* Enhanced enclave session initialization and DEK unwrapping to support tenant ID and API key authentication via a custom HTTP round tripper. [[1]](diffhunk://#diff-f4ba5fd5e5c9db6a0b1f028d237d5f8f2aee754f499d715fc5577b597ccee5efR41-R44) [[2]](diffhunk://#diff-f4ba5fd5e5c9db6a0b1f028d237d5f8f2aee754f499d715fc5577b597ccee5efR64-R83) [[3]](diffhunk://#diff-f4ba5fd5e5c9db6a0b1f028d237d5f8f2aee754f499d715fc5577b597ccee5efL76-R100) [[4]](diffhunk://#diff-f4ba5fd5e5c9db6a0b1f028d237d5f8f2aee754f499d715fc5577b597ccee5efL295-R319) [[5]](diffhunk://#diff-f4ba5fd5e5c9db6a0b1f028d237d5f8f2aee754f499d715fc5577b597ccee5efL309-R333)

**API Request/Response Model Updates**
* Added `blob_size` to `CreateObjectRequest` for storage method selection, and introduced new types for scan requests/responses. [[1]](diffhunk://#diff-55b077d86fc686e6bacbad10ee30f20ef35937bb1a4a61358863d0fa5c0f19b0R10-R22) [[2]](diffhunk://#diff-04ed20f2eab74d520499f9c460391327cee0671d1a84fb784c1f7fa6520a3fc7L17-R33)

**Miscellaneous**
* Replaced bcrypt-based hashing with SHA-256 and base64 encoding in enclave service utility functions for improved performance and consistency.