### PR TITLE
Fix SCAN pagination, API pkg v0.0.5

### DIFF
--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -3,7 +3,7 @@ module github.com/QodeSrl/gardbase/apps/api
 go 1.24.4
 
 require (
-	github.com/QodeSrl/gardbase/pkg/api v0.0.1
+	github.com/QodeSrl/gardbase/pkg/api v0.0.5
 	github.com/QodeSrl/gardbase/pkg/enclaveproto v0.0.4
 	github.com/QodeSrl/gardbase/pkg/models v0.0.6
 	github.com/aws/aws-sdk-go-v2 v1.41.0

--- a/apps/api/internal/handlers/objects.go
+++ b/apps/api/internal/handlers/objects.go
@@ -275,14 +275,14 @@ func (h *ObjectHandler) Scan(c *gin.Context) {
 		nextToken = *req.NextToken
 	}
 
-	objs, err := h.Dynamo.ScanTable(ctx, tenantId, req.TableHash, req.Limit, nextToken)
+	result, err := h.Dynamo.ScanTable(ctx, tenantId, req.TableHash, req.Limit, nextToken)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to scan objects from DynamoDB: " + err.Error()})
 		return
 	}
 
 	var resp objects.ScanResponse
-	for _, obj := range objs {
+	for _, obj := range result.Objects {
 		resp.Objects = append(resp.Objects, objects.ResultObject{
 			ObjectID:         obj.SK[len("OBJ#"):],
 			GetURL:           obj.S3Key,
@@ -295,6 +295,7 @@ func (h *ObjectHandler) Scan(c *gin.Context) {
 			Version:          obj.Version,
 		})
 	}
+	resp.NextToken = result.NextToken
 
 	c.JSON(http.StatusOK, resp)
 }

--- a/apps/api/internal/handlers/objects.go
+++ b/apps/api/internal/handlers/objects.go
@@ -270,7 +270,12 @@ func (h *ObjectHandler) Scan(c *gin.Context) {
 		return
 	}
 
-	objs, err := h.Dynamo.ScanTable(ctx, tenantId, req.TableHash, req.Limit, *req.NextToken)
+	nextToken := ""
+	if req.NextToken != nil {
+		nextToken = *req.NextToken
+	}
+
+	objs, err := h.Dynamo.ScanTable(ctx, tenantId, req.TableHash, req.Limit, nextToken)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to scan objects from DynamoDB: " + err.Error()})
 		return

--- a/pkg/api/objects/responses.go
+++ b/pkg/api/objects/responses.go
@@ -29,5 +29,6 @@ type ResultObject struct {
 type GetObjectResponse = ResultObject
 
 type ScanResponse struct {
-	Objects []ResultObject `json:"objects"`
+	Objects   []ResultObject `json:"objects"`
+	NextToken *string        `json:"next_token,omitempty"`
 }

--- a/pkg/crypto/go.mod
+++ b/pkg/crypto/go.mod
@@ -10,7 +10,7 @@ require (
 )
 
 require (
-	github.com/QodeSrl/gardbase/pkg/api v0.0.1
+	github.com/QodeSrl/gardbase/pkg/api v0.0.5
 	github.com/QodeSrl/gardbase/pkg/enclaveproto v0.0.4
 	golang.org/x/crypto v0.47.0
 )

--- a/pkg/crypto/go.sum
+++ b/pkg/crypto/go.sum
@@ -3,4 +3,6 @@ github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj2
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
+golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
This pull request introduces improvements to the DynamoDB object scanning functionality and updates dependencies across the project. The main focus is on enhancing the `ScanTable` method to support pagination by returning a `NextToken`, which allows clients to fetch additional results in subsequent requests. Additionally, the API and response structures are updated to accommodate these changes.

**Enhancements to DynamoDB Scanning and Pagination:**

- Refactored the `ScanTable` method in `dynamo.go` to return a new `ScanResult` struct containing both the list of objects and a `NextToken` for pagination. The method now also uses `KeyConditionExpression` and `ExpressionAttributeValues` for DynamoDB queries, improving query clarity and maintainability. [[1]](diffhunk://#diff-550cd3c22e36952ec37b615b2ee3b46cf1370227069aeeaa3298301282851f21L309-R323) [[2]](diffhunk://#diff-550cd3c22e36952ec37b615b2ee3b46cf1370227069aeeaa3298301282851f21L343-R354)
- Updated the `ObjectHandler.Scan` method in `objects.go` to handle the new `ScanResult` structure, passing the `NextToken` from the request and returning it in the response. [[1]](diffhunk://#diff-64fe0d64996ab921818dabbdbf5dc0212e5ed6d8fc7b3d968740f7aef32efc1aL273-R285) [[2]](diffhunk://#diff-64fe0d64996ab921818dabbdbf5dc0212e5ed6d8fc7b3d968740f7aef32efc1aR298)

**API Response and Dependency Updates:**

- Modified the `ScanResponse` struct in `responses.go` to include an optional `NextToken` field for pagination support.
- Updated the `github.com/QodeSrl/gardbase/pkg/api` dependency to version `v0.0.5` in both `apps/api/go.mod` and `pkg/crypto/go.mod` to ensure compatibility with the new response structure. [[1]](diffhunk://#diff-95186a420196058312431019392b33839b84201f95c5c2e5cdea9fa18f5b9dd6L6-R6) [[2]](diffhunk://#diff-d63f17374122c06d451bdf06295f849045b27cbec4c7ef19f1b78111c597a57bL13-R13)

**DynamoDB Query Improvements:**

- Replaced deprecated `KeyConditions` with `KeyConditionExpression` and `ExpressionAttributeValues` in both `FindAPIKey` and `ScanTable` methods for more modern and maintainable DynamoDB queries. [[1]](diffhunk://#diff-550cd3c22e36952ec37b615b2ee3b46cf1370227069aeeaa3298301282851f21L278-R280) [[2]](diffhunk://#diff-550cd3c22e36952ec37b615b2ee3b46cf1370227069aeeaa3298301282851f21L309-R323)