### PR TITLE
Update import names, crypto pkg v0.2.0

### DIFF
--- a/apps/api/cmd/server/main.go
+++ b/apps/api/cmd/server/main.go
@@ -9,15 +9,15 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/QodeSrl/gardbase/apps/api/internal/handlers"
-	"github.com/QodeSrl/gardbase/apps/api/internal/middleware"
-	"github.com/QodeSrl/gardbase/apps/api/internal/services"
-	"github.com/QodeSrl/gardbase/apps/api/internal/storage"
-	"github.com/QodeSrl/gardbase/pkg/models"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/gin-gonic/gin"
+	"github.com/qodesrl/gardbase/apps/api/internal/handlers"
+	"github.com/qodesrl/gardbase/apps/api/internal/middleware"
+	"github.com/qodesrl/gardbase/apps/api/internal/services"
+	"github.com/qodesrl/gardbase/apps/api/internal/storage"
+	"github.com/qodesrl/gardbase/pkg/models"
 	"go.uber.org/zap"
 )
 

--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -1,11 +1,11 @@
-module github.com/QodeSrl/gardbase/apps/api
+module github.com/qodesrl/gardbase/apps/api
 
 go 1.24.4
 
 require (
-	github.com/QodeSrl/gardbase/pkg/api v0.1.0
-	github.com/QodeSrl/gardbase/pkg/enclaveproto v0.1.0
-	github.com/QodeSrl/gardbase/pkg/models v0.1.0
+	github.com/qodesrl/gardbase/pkg/api v0.1.0
+	github.com/qodesrl/gardbase/pkg/enclaveproto v0.1.0
+	github.com/qodesrl/gardbase/pkg/models v0.1.0
 	github.com/aws/aws-sdk-go-v2 v1.41.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.5
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.29
@@ -76,8 +76,8 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 )
 
-replace github.com/QodeSrl/gardbase/pkg/models => ../../pkg/models
+replace github.com/qodesrl/gardbase/pkg/models => ../../pkg/models
 
-replace github.com/QodeSrl/gardbase/pkg/enclaveproto => ../../pkg/enclaveproto
+replace github.com/qodesrl/gardbase/pkg/enclaveproto => ../../pkg/enclaveproto
 
-replace github.com/QodeSrl/gardbase/pkg/api => ../../pkg/api
+replace github.com/qodesrl/gardbase/pkg/api => ../../pkg/api

--- a/apps/api/internal/handlers/encryption.go
+++ b/apps/api/internal/handlers/encryption.go
@@ -6,11 +6,11 @@ import (
 	"log"
 	"time"
 
-	"github.com/QodeSrl/gardbase/apps/api/internal/services"
-	"github.com/QodeSrl/gardbase/apps/api/internal/storage"
-	"github.com/QodeSrl/gardbase/pkg/api/encryption"
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
 	"github.com/gin-gonic/gin"
+	"github.com/qodesrl/gardbase/apps/api/internal/services"
+	"github.com/qodesrl/gardbase/apps/api/internal/storage"
+	"github.com/qodesrl/gardbase/pkg/api/encryption"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
 )
 
 type EncryptionHandler struct {

--- a/apps/api/internal/handlers/healthCheck.go
+++ b/apps/api/internal/handlers/healthCheck.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/QodeSrl/gardbase/apps/api/internal/services"
-	"github.com/QodeSrl/gardbase/apps/api/internal/storage"
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
 	"github.com/gin-gonic/gin"
+	"github.com/qodesrl/gardbase/apps/api/internal/services"
+	"github.com/qodesrl/gardbase/apps/api/internal/storage"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
 )
 
 type HealthCheckHandler struct {

--- a/apps/api/internal/handlers/objects.go
+++ b/apps/api/internal/handlers/objects.go
@@ -7,13 +7,13 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/QodeSrl/gardbase/apps/api/internal/services"
-	"github.com/QodeSrl/gardbase/apps/api/internal/storage"
-	"github.com/QodeSrl/gardbase/pkg/api/objects"
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
-	"github.com/QodeSrl/gardbase/pkg/models"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/qodesrl/gardbase/apps/api/internal/services"
+	"github.com/qodesrl/gardbase/apps/api/internal/storage"
+	"github.com/qodesrl/gardbase/pkg/api/objects"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
+	"github.com/qodesrl/gardbase/pkg/models"
 )
 
 type ObjectHandler struct {

--- a/apps/api/internal/handlers/tenants.go
+++ b/apps/api/internal/handlers/tenants.go
@@ -4,12 +4,12 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/QodeSrl/gardbase/apps/api/internal/services"
-	"github.com/QodeSrl/gardbase/apps/api/internal/storage"
-	"github.com/QodeSrl/gardbase/pkg/api/tenants"
-	"github.com/QodeSrl/gardbase/pkg/models"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/qodesrl/gardbase/apps/api/internal/services"
+	"github.com/qodesrl/gardbase/apps/api/internal/storage"
+	"github.com/qodesrl/gardbase/pkg/api/tenants"
+	"github.com/qodesrl/gardbase/pkg/models"
 )
 
 type TenantHandler struct {

--- a/apps/api/internal/middleware/tenant.go
+++ b/apps/api/internal/middleware/tenant.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"regexp"
 
-	"github.com/QodeSrl/gardbase/apps/api/internal/storage"
 	"github.com/gin-gonic/gin"
+	"github.com/qodesrl/gardbase/apps/api/internal/storage"
 )
 
 type tenantKeyType string

--- a/apps/api/internal/services/enclaveVSock.go
+++ b/apps/api/internal/services/enclaveVSock.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
 	"github.com/mdlayher/vsock"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
 )
 
 type VsockPool struct {

--- a/apps/api/internal/storage/dynamo.go
+++ b/apps/api/internal/storage/dynamo.go
@@ -10,13 +10,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/QodeSrl/gardbase/pkg/api/objects"
-	"github.com/QodeSrl/gardbase/pkg/models"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	ddbTypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/google/uuid"
+	"github.com/qodesrl/gardbase/pkg/api/objects"
+	"github.com/qodesrl/gardbase/pkg/models"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/apps/enclave-service/cmd/enclave/main.go
+++ b/apps/enclave-service/cmd/enclave/main.go
@@ -17,11 +17,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/handlers"
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/utils"
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
 	"github.com/hf/nsm"
 	"github.com/mdlayher/vsock"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/handlers"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/utils"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
 )
 
 var (

--- a/apps/enclave-service/go.mod
+++ b/apps/enclave-service/go.mod
@@ -1,9 +1,9 @@
-module github.com/QodeSrl/gardbase/apps/enclave-service
+module github.com/qodesrl/gardbase/apps/enclave-service
 
 go 1.24.4
 
 require (
-	github.com/QodeSrl/gardbase/pkg/enclaveproto v0.1.0
+	github.com/qodesrl/gardbase/pkg/enclaveproto v0.1.0
 	github.com/hf/nsm v0.0.0-20220930140112-cd181bd646b9
 	github.com/mdlayher/vsock v1.2.1
 	golang.org/x/crypto v0.47.0
@@ -19,4 +19,4 @@ require (
 	golang.org/x/sys v0.40.0 // indirect
 )
 
-replace github.com/QodeSrl/gardbase/pkg/enclaveproto => ../../pkg/enclaveproto
+replace github.com/qodesrl/gardbase/pkg/enclaveproto => ../../pkg/enclaveproto

--- a/apps/enclave-service/internal/handlers/decrypt.go
+++ b/apps/enclave-service/internal/handlers/decrypt.go
@@ -6,10 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
 	"golang.org/x/crypto/nacl/box"
 
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/utils"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/utils"
 )
 
 func HandleDecrypt(encoder *json.Encoder, payload json.RawMessage, nsmPrivKey *rsa.PrivateKey) {

--- a/apps/enclave-service/internal/handlers/get_attestation.go
+++ b/apps/enclave-service/internal/handlers/get_attestation.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/utils"
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/utils"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
 )
 
 func HandleGetAttestation(encoder *json.Encoder, attestation *utils.Attestation) {

--- a/apps/enclave-service/internal/handlers/health.go
+++ b/apps/enclave-service/internal/handlers/health.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/utils"
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/utils"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
 )
 
 func HandleHealth(encoder *json.Encoder, startTime time.Time) {

--- a/apps/enclave-service/internal/handlers/prepare_kek.go
+++ b/apps/enclave-service/internal/handlers/prepare_kek.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
 	"github.com/hf/nsm"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
 	"golang.org/x/crypto/nacl/box"
 
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/utils"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/utils"
 )
 
 func HandlePrepareKEK(encoder *json.Encoder, payload json.RawMessage, nsmSession *nsm.Session, nsmPrivKey *rsa.PrivateKey) {

--- a/apps/enclave-service/internal/handlers/session_generate_table_hash.go
+++ b/apps/enclave-service/internal/handlers/session_generate_table_hash.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/session"
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/utils"
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/session"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/utils"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
 	"golang.org/x/crypto/chacha20poly1305"
 )
 

--- a/apps/enclave-service/internal/handlers/session_init.go
+++ b/apps/enclave-service/internal/handlers/session_init.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/session"
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/utils"
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
 	"github.com/hf/nsm"
 	"github.com/hf/nsm/request"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/session"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/utils"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
 	"golang.org/x/crypto/curve25519"
 )
 

--- a/apps/enclave-service/internal/handlers/session_prepare_dek.go
+++ b/apps/enclave-service/internal/handlers/session_prepare_dek.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/session"
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/utils"
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
 	"github.com/hf/nsm"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/session"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/utils"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
 	"golang.org/x/crypto/chacha20poly1305"
 )
 

--- a/apps/enclave-service/internal/handlers/session_prepare_iek.go
+++ b/apps/enclave-service/internal/handlers/session_prepare_iek.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/session"
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/utils"
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
 	"github.com/hf/nsm"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/session"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/utils"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
 	"golang.org/x/crypto/chacha20poly1305"
 )
 

--- a/apps/enclave-service/internal/handlers/session_unwrap.go
+++ b/apps/enclave-service/internal/handlers/session_unwrap.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/session"
-	"github.com/QodeSrl/gardbase/apps/enclave-service/internal/utils"
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
 	"github.com/hf/nsm"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/session"
+	"github.com/qodesrl/gardbase/apps/enclave-service/internal/utils"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
 	"golang.org/x/crypto/chacha20poly1305"
 )
 

--- a/apps/enclave-service/internal/utils/connection.go
+++ b/apps/enclave-service/internal/utils/connection.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
 )
 
 func SendResponse[T any](encoder *json.Encoder, res enclaveproto.Response[T]) {

--- a/pkg/api/encryption/requests.go
+++ b/pkg/api/encryption/requests.go
@@ -1,6 +1,6 @@
 package encryption
 
-import "github.com/QodeSrl/gardbase/pkg/enclaveproto"
+import "github.com/qodesrl/gardbase/pkg/enclaveproto"
 
 type SessionInitRequest = enclaveproto.SessionInitRequest
 

--- a/pkg/api/encryption/responses.go
+++ b/pkg/api/encryption/responses.go
@@ -1,6 +1,6 @@
 package encryption
 
-import "github.com/QodeSrl/gardbase/pkg/enclaveproto"
+import "github.com/qodesrl/gardbase/pkg/enclaveproto"
 
 type SessionInitResponse = enclaveproto.SessionInitResponse
 

--- a/pkg/api/go.mod
+++ b/pkg/api/go.mod
@@ -1,7 +1,7 @@
-module github.com/QodeSrl/gardbase/pkg/api
+module github.com/qodesrl/gardbase/pkg/api
 
 go 1.24.4
 
-require github.com/QodeSrl/gardbase/pkg/enclaveproto v0.1.0
+require github.com/qodesrl/gardbase/pkg/enclaveproto v0.1.0
 
-replace github.com/QodeSrl/gardbase/pkg/enclaveproto => ../enclaveproto
+replace github.com/qodesrl/gardbase/pkg/enclaveproto => ../enclaveproto

--- a/pkg/crypto/go.mod
+++ b/pkg/crypto/go.mod
@@ -1,4 +1,4 @@
-module github.com/QodeSrl/gardbase/pkg/crypto
+module github.com/qodesrl/gardbase/pkg/crypto
 
 go 1.24.4
 
@@ -10,11 +10,11 @@ require (
 )
 
 require (
-	github.com/QodeSrl/gardbase/pkg/api v0.1.0
-	github.com/QodeSrl/gardbase/pkg/enclaveproto v0.1.0
+	github.com/qodesrl/gardbase/pkg/api v0.1.0
+	github.com/qodesrl/gardbase/pkg/enclaveproto v0.1.0
 	golang.org/x/crypto v0.47.0
 )
 
-replace github.com/QodeSrl/gardbase/pkg/enclaveproto => ../enclaveproto
+replace github.com/qodesrl/gardbase/pkg/enclaveproto => ../enclaveproto
 
-replace github.com/QodeSrl/gardbase/pkg/api => ../api
+replace github.com/qodesrl/gardbase/pkg/api => ../api

--- a/pkg/crypto/go.mod
+++ b/pkg/crypto/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/alessandrofoglia07/goope v0.1.1
 	github.com/qodesrl/gardbase/pkg/api v0.1.0
 	github.com/qodesrl/gardbase/pkg/enclaveproto v0.1.0
 	golang.org/x/crypto v0.47.0

--- a/pkg/crypto/go.sum
+++ b/pkg/crypto/go.sum
@@ -1,3 +1,5 @@
+github.com/alessandrofoglia07/goope v0.1.1 h1:TY2OxKuuyZs/RN75e1q3WJMfg3CMhvJT6hNnEHl/4g0=
+github.com/alessandrofoglia07/goope v0.1.1/go.mod h1:1PrGBznXBlFdWTPgJFz0NLtyByj7Pl11fYPFGyFMqO4=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/pkg/crypto/kms.go
+++ b/pkg/crypto/kms.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/QodeSrl/gardbase/pkg/api/encryption"
-	"github.com/QodeSrl/gardbase/pkg/enclaveproto"
+	"github.com/qodesrl/gardbase/pkg/api/encryption"
+	"github.com/qodesrl/gardbase/pkg/enclaveproto"
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/crypto/nacl/box"
 )

--- a/pkg/crypto/ope.go
+++ b/pkg/crypto/ope.go
@@ -1,4 +1,4 @@
-// Order-Preserving and Range-Query Encryption using AES-GCM.
+// Order-Preserving and Range-Query Encryption.
 //
 // CRITICAL SECURITY WARNING
 // Order-preserving encryption (OPE) leaks order, approximate values, distribution, and frequency information.
@@ -7,166 +7,198 @@
 package crypto
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
 	"time"
+
+	"github.com/alessandrofoglia07/goope"
 )
 
-func NormalizeInt64(v int64) uint64 {
-	// from int64 range [-2^63, 2^63-1] to uint64 range [0, 2^64-1]
-	// XOR with the sign bit to flip the range: negative numbers (sign bit 1) become smaller, positive numbers (sign bit 0) become larger
-	return uint64(v) + (1 << 63)
+var opeIn32, opeOut64 goope.ValueRange
+
+func init() {
+	var err error
+	opeIn32, err = goope.NewValueRange(0, math.MaxUint32) // for 32-bit normalized values
+	if err != nil {
+		panic(fmt.Sprintf("failed to initialize OPE input range: %v", err))
+	}
+	opeOut64, err = goope.NewValueRange(0, math.MaxInt64>>2) // wide ciphertext range to reduce risk of collisions
+	if err != nil {
+		panic(fmt.Sprintf("failed to initialize OPE output range: %v", err))
+	}
 }
 
-func DenormalizeInt64(v uint64) int64 {
-	// from uint64 range [0, 2^64-1] back to int64 range [-2^63, 2^63-1]
-	return int64(v - (1 << 63))
+func NormalizeInt64OPE(v int64) int64 {
+	// flip sign bit so negatives sort below positives, then take high 32 bits
+	ordered := uint64(v) ^ (1 << 63)
+	return int64(ordered >> 32) // range [0, 2^32-1] for all int64 values
 }
 
-func NormalizeInt32(v int32) uint64 {
-	// from int32 range [-2^31, 2^31-1] to uint64 range [0, 2^64-1]
-	// the full uint64 range is not used; values fit in [0, 2^32-1]
-	return uint64(uint32(v) ^ (1 << 31))
+func DenormalizeInt64OPE(v int64) int64 {
+	// from int64 range [0, 2^32-1] back to int64 range [-2^63, 2^63-1]
+	ordered := uint64(v) << 32
+	return int64(ordered ^ (1 << 63))
 }
 
-func DenormalizeInt32(v uint64) int32 {
-	// from uint64 range [0, 2^64-1] back to int32 range [-2^31, 2^31-1]
+func NormalizeInt32OPE(v int32) int64 {
+	// XOR with sign bit maps [-2^31, 2^31-1] to [0, 2^32-1]
+	return int64(uint32(v) ^ (1 << 31))
+}
+
+func DenormalizeInt32OPE(v int64) int32 {
+	// from int64 range [0, 2^32-1] back to int32 range [-2^31, 2^31-1]
 	return int32(uint32(v) ^ (1 << 31))
 }
 
-func NormalizeFloat64(v float64) uint64 {
-	if math.IsNaN(v) {
-		panic("NaN cannot be encrypted with OPE")
-	}
-	bits := math.Float64bits(v)
-	if bits>>63 == 0 {
-		// positive (including +0.0, +Inf): flip sign bit
-		return bits ^ (1 << 63)
-	}
-	// negative (including -0.0, -Inf): flip all bits
-	return ^bits
+func NormalizeUint32OPE(v uint32) int64 {
+	return int64(v)
 }
 
-func DenormalizeFloat64(v uint64) float64 {
-	var bits uint64
-	if v>>63 == 0 {
-		// was positive: flip sign bit back
-		bits = v ^ (1 << 63)
+func DenormalizeUint32OPE(v int64) uint32 {
+	return uint32(v)
+}
+
+func NormalizeFloat64OPE(v float64) (int64, error) {
+	if math.IsNaN(v) {
+		return 0, errors.New("NaN cannot be encrypted with OPE")
+	}
+	bits := math.Float64bits(v)
+	var ordered uint64
+	if bits>>63 == 0 {
+		ordered = bits ^ (1 << 63) // positive: flip sign bit
 	} else {
-		// was negative: flip all bits back
-		bits = ^v
+		ordered = ^bits // negative: flip all bits
+	}
+	return int64(ordered >> 32), nil
+}
+
+func DenormalizeFloat64OPE(v int64) float64 {
+	ordered := uint64(v) << 32
+	var bits uint64
+	if ordered>>63 == 1 {
+		bits = ordered ^ (1 << 63) // was positive: flip sign bit back
+	} else {
+		bits = ^ordered // was negative: flip all bits back
 	}
 	return math.Float64frombits(bits)
 }
 
-func NormalizeFloat32(v float32) uint64 {
+func NormalizeFloat32OPE(v float32) (int64, error) {
 	if math.IsNaN(float64(v)) {
-		panic("NaN cannot be encrypted with OPE")
+		return 0, errors.New("NaN cannot be encrypted with OPE")
 	}
-	bits := uint64(math.Float32bits(v))
+	bits := math.Float32bits(v)
+	var ordered uint32
 	if bits>>31 == 0 {
-		return bits ^ (1 << 31)
+		ordered = bits ^ (1 << 31) // positive: flip sign bit
+	} else {
+		ordered = ^bits // negative: flip all bits
 	}
-	return uint64(^uint32(bits))
+	return int64(ordered), nil
 }
 
-func DenormalizeFloat32(v uint64) float32 {
+func DenormalizeFloat32OPE(v int64) float32 {
 	u := uint32(v)
 	var bits uint32
 	if u>>31 == 1 {
-		bits = u ^ (1 << 31)
+		bits = u ^ (1 << 31) // was positive: flip sign bit back
 	} else {
-		bits = ^u
+		bits = ^u // was negative: flip all bits back
 	}
 	return math.Float32frombits(bits)
 }
 
-// Second-level normalization for time values to preserve order and allow range queries while encrypting with OPE.
-func NormalizeTime(t time.Time) uint64 {
-	return NormalizeTimeSeconds(t)
+func NormalizeTimeOPE(t time.Time) (int64, error) {
+	unix := t.UTC().Unix()
+	if unix < 0 || unix > math.MaxUint32 {
+		return 0, fmt.Errorf("timestamp %v out of OPE range [0, 2^32-1]: use NormalizeTimeExtendedOPE", t)
+	}
+	return unix, nil
 }
 
-func DenormalizeTime(v uint64) time.Time {
-	return DenormalizeTimeSeconds(v)
+func DenormalizeTimeOPE(v int64) time.Time {
+	return time.Unix(v, 0).UTC()
 }
 
-// Use NormalizeTimeSeconds for historical dates or far-future timestamps
-func NormalizeTimeSeconds(t time.Time) uint64 {
-	return NormalizeInt64(t.UTC().Unix())
+// NormalizeTimeExtendedOPE handles timestamps before 1970 or after 2106 by
+// mapping Unix seconds (int64) using the same high-32-bit truncation as
+// NormalizeInt64OPE. Precision is ~136 years per unit.
+func NormalizeTimeExtendedOPE(t time.Time) int64 {
+	return NormalizeInt64OPE(t.UTC().Unix())
 }
 
-func DenormalizeTimeSeconds(v uint64) time.Time {
-	return time.Unix(DenormalizeInt64(v), 0).UTC()
+func DenormalizeTimeExtendedOPE(v int64) time.Time {
+	return time.Unix(DenormalizeInt64OPE(v), 0).UTC()
 }
 
-func NormalizeUint32(v uint32) uint64 {
-	// from uint32 range [0, 2^32-1] to uint64 range [0, 2^64-1]
-	return uint64(v)
-}
-
-func DenormalizeUint32(v uint64) uint32 {
-	// from uint64 range [0, 2^64-1] back to uint32 range [0, 2^32-1]
-	return uint32(v)
-}
-
-func NormalizeValue(v any) (uint64, error) {
+func NormalizeValueOPE(v any) (int64, error) {
 	switch val := v.(type) {
+	case int64:
+		return NormalizeInt64OPE(val), nil
+	case int32:
+		return NormalizeInt32OPE(val), nil
+	case float32:
+		return NormalizeFloat32OPE(val)
+	case float64:
+		return NormalizeFloat64OPE(val)
+	case uint32:
+		return NormalizeUint32OPE(val), nil
+	case uint64:
+		return 0, errors.New("uint64 cannot be losslessly normalized for OPE: range exceeds int64; use uint32 or truncate manually")
+	case int:
+		return NormalizeInt64OPE(int64(val)), nil
+	case uint:
+		if val > math.MaxUint32 {
+			return 0, fmt.Errorf("uint value %d exceeds OPE input range; cast to uint32 explicitly", val)
+		}
+		return NormalizeUint32OPE(uint32(val)), nil
+	case time.Duration:
+		return NormalizeInt64OPE(int64(val)), nil
+	case int16:
+		return NormalizeInt32OPE(int32(val)), nil
+	case int8:
+		return NormalizeInt32OPE(int32(val)), nil
+	case uint16:
+		return NormalizeUint32OPE(uint32(val)), nil
+	case uint8:
+		return NormalizeUint32OPE(uint32(val)), nil
 	case time.Time:
-		return NormalizeTime(val), nil
+		return NormalizeTimeOPE(val)
 	case *time.Time:
 		if val == nil {
 			return 0, errors.New("cannot normalize nil time pointer")
 		}
-		return NormalizeTime(*val), nil
-	case int64:
-		return NormalizeInt64(val), nil
-	case int32:
-		return NormalizeInt32(val), nil
-	case float64:
-		return NormalizeFloat64(val), nil
-	case float32:
-		return NormalizeFloat32(val), nil
-	case uint32:
-		return NormalizeUint32(val), nil
+		return NormalizeTimeOPE(*val)
 	default:
 		return 0, fmt.Errorf("unsupported type for normalization: %T", v)
 	}
 }
 
-// WARNING: This is trivially breakable with known plaintext attacks
-// TODO: Replace with a more secure OPE scheme (CRITICAL!!!!!)
-// Could replace this algorithm with a ported version of pyope (https://github.com/tonyo/pyope), which implements Boldyreva's symmetric OPE scheme.
-//
-// ct format: encrypted value (8 bytes)
-func EncryptObjectLinearOPE(plaintext uint64, dek []byte) ([]byte, error) {
+func EncryptObjectOPE(plaintext int64, dek []byte) ([]byte, error) {
 	if len(dek) != AESKeySize {
 		return nil, fmt.Errorf("invalid DEK size: %d", len(dek))
 	}
 
-	// Encrypt plaintext with DEK using linear OPE
+	ope, err := goope.NewOPE(dek, &opeIn32, &opeOut64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OPE instance: %w", err)
+	}
 
-	// Derive slope and intercept from key
-	a, b := deriveLinearParams(dek)
-
-	// Perform linear transformation
-	// This preserves order: if pt1 < pt2, then ct1 < ct2
-	ciphertext := (a * plaintext) + b
+	ciphertext, err := ope.Encrypt(plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt with OPE: %w", err)
+	}
 
 	// Encode as bytes
 	ct := make([]byte, 8)
-	binary.BigEndian.PutUint64(ct, ciphertext)
+	binary.BigEndian.PutUint64(ct, uint64(ciphertext))
 
 	return ct, nil
 }
 
-// DecryptObjectLinearOPE decrypts data encrypted with EncryptObjectLinearOPE.
-// Performs inverse linear transformation: pt = (ct - b) / a
-func DecryptObjectLinearOPE(ct []byte, dek []byte) (uint64, error) {
-	// Decrypt ciphertext with DEK
+func DecryptObjectOPE(ct []byte, dek []byte) (int64, error) {
 	if len(dek) != AESKeySize {
 		return 0, fmt.Errorf("invalid key size: %d", len(dek))
 	}
@@ -174,29 +206,18 @@ func DecryptObjectLinearOPE(ct []byte, dek []byte) (uint64, error) {
 		return 0, errors.New("invalid ciphertext size")
 	}
 
-	// Derive slope and intercept from key
-	a, b := deriveLinearParams(dek)
+	ope, err := goope.NewOPE(dek, &opeIn32, &opeOut64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create OPE instance: %w", err)
+	}
 
 	// Decode ciphertext
-	ciphertext := binary.BigEndian.Uint64(ct)
+	raw := int64(binary.BigEndian.Uint64(ct))
 
-	// Perform inverse transformation
-	plaintext := (ciphertext - b) / a
+	plaintext, err := ope.Decrypt(raw)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decrypt with OPE: %w", err)
+	}
 
 	return plaintext, nil
-}
-
-// deriveLinearParams derives slope (a) and intercept (b) from key
-func deriveLinearParams(key []byte) (a uint64, b uint64) {
-	h := hmac.New(sha256.New, key)
-	h.Write([]byte("linear-ope-slope"))
-	slopeBytes := h.Sum(nil)
-	a = (binary.BigEndian.Uint64(slopeBytes[:8]) >> 48) | 1 // Ensure odd (coprime with 2^64)
-
-	h.Reset()
-	h.Write([]byte("linear-ope-intercept"))
-	interceptBytes := h.Sum(nil)
-	b = binary.BigEndian.Uint64(interceptBytes[:8]) >> 16
-
-	return a, b
 }

--- a/pkg/enclaveproto/go.mod
+++ b/pkg/enclaveproto/go.mod
@@ -1,3 +1,3 @@
-module github.com/QodeSrl/gardbase/pkg/enclaveproto
+module github.com/qodesrl/gardbase/pkg/enclaveproto
 
 go 1.24.4

--- a/pkg/models/go.mod
+++ b/pkg/models/go.mod
@@ -1,4 +1,4 @@
-module github.com/QodeSrl/gardbase/pkg/models
+module github.com/qodesrl/gardbase/pkg/models
 
 go 1.24.4
 


### PR DESCRIPTION
This pull request updates all references to the `QodeSrl` Go module namespace to use the lowercase `qodesrl` namespace throughout the codebase. This change ensures consistency and resolves potential import errors due to case sensitivity in Go module paths.

The most important changes are:

**Module path and import updates:**

* Crypto pkg v0.2.0, implements the new `goope` algorithm for secure OPE.
* Updated the `module` declarations and all `require` and `replace` statements in `go.mod` files for both `apps/api` and `apps/enclave-service` to use `github.com/qodesrl/gardbase/...` instead of `github.com/QodeSrl/gardbase/...`. 
* Changed all import statements in Go source files under `apps/api` and `apps/enclave-service` to use the lowercase `qodesrl` module path. This affects imports in handler, middleware, service, and storage packages.
