### PR TITLE
Clean up landing copy: drop process-leak text and dedupe slop

### DIFF
--- a/apps/landing/src/components/FeaturesSection.tsx
+++ b/apps/landing/src/components/FeaturesSection.tsx
@@ -32,7 +32,7 @@ const features = [
   {
     icon: LuDatabase,
     title: "Hybrid DynamoDB + S3",
-    desc: "Small encrypted objects live inline in DynamoDB; large blobs go to S3 with wrapped DEKs in metadata. Scalable by default.",
+    desc: "Small encrypted objects live inline in DynamoDB; large blobs go to S3 with wrapped DEKs in metadata. Storage scales without extra wiring.",
   },
   {
     icon: LuGitBranch,
@@ -54,7 +54,7 @@ const FeaturesSection: React.FC = () => {
             Capabilities
           </span>
           <h2 className="mt-3 text-3xl font-bold tracking-tight text-fg sm:text-4xl md:text-5xl">
-            Real encryption, real database ergonomics
+            Strong encryption, full database ergonomics
           </h2>
           <p className="mx-auto mt-4 max-w-2xl text-base text-muted sm:text-lg">
             Zero-trust security usually means giving up querying, sorting, and developer experience.

--- a/apps/landing/src/components/HowItWorksSection.tsx
+++ b/apps/landing/src/components/HowItWorksSection.tsx
@@ -38,7 +38,7 @@ const HowItWorksSection: React.FC = () => {
             How it works
           </span>
           <h2 className="mt-3 text-3xl font-bold tracking-tight text-fg sm:text-4xl md:text-5xl">
-            Trust you can verify, not just assume
+            Zero plaintext ever reaches the server
           </h2>
           <p className="mx-auto mt-4 max-w-2xl text-base text-muted sm:text-lg">
             Three steps from your application to provably confidential storage.

--- a/apps/landing/src/components/PricingSection.tsx
+++ b/apps/landing/src/components/PricingSection.tsx
@@ -36,7 +36,7 @@ const plans: Plan[] = [
     features: [
       "Fully managed Nitro Enclave fleet",
       "Automated key management & rotation",
-      "Usage-based pricing — no mock numbers",
+      "Transparent usage-based pricing",
       "Dashboards, metrics & alerts",
       "Priority support",
     ],
@@ -124,7 +124,7 @@ const PricingSection: React.FC = () => {
         </div>
 
         <p className="mt-8 text-center text-xs text-subtle sm:text-sm">
-          Managed cloud pricing will be published when it launches — no placeholder numbers here.
+          Managed cloud pricing will be published at launch. Request early access to be the first to know.
         </p>
       </div>
     </section>

--- a/apps/landing/src/components/ProblemStatementSection.tsx
+++ b/apps/landing/src/components/ProblemStatementSection.tsx
@@ -12,7 +12,7 @@ const gardbase = [
   "Data is encrypted client-side — the server only holds ciphertext",
   "Keys are unwrapped only inside attested AWS Nitro Enclaves",
   "Searchable indexes work directly on encrypted data",
-  "Zero-trust by design — and you can cryptographically verify it",
+  "Zero-trust architecture — and you can cryptographically verify it",
 ];
 
 const ProblemStatementSection: React.FC = () => {


### PR DESCRIPTION
- Remove meta-commentary about avoiding placeholders from the pricing section ("no mock numbers", "no placeholder numbers here")
- Dedupe the repeated "trust vs. verify/promise/assume" headline template (now only in the ProblemStatement contrast and OpenSource section)
- Thin the "by design / by default" tic so it lives only in the footer tagline
- Fix the doubled "real" in the Features headline