### PR TITLE
Rewrite hero/CTA/problem copy: defensible claims, sharper value

### DIFF
--- a/apps/landing/src/components/CTASection.tsx
+++ b/apps/landing/src/components/CTASection.tsx
@@ -16,12 +16,12 @@ const CTASection: React.FC = () => {
           />
           <div className="relative">
             <h2 className="mx-auto max-w-2xl text-3xl font-bold tracking-tight text-white sm:text-4xl md:text-5xl">
-              Build on a database that{" "}
-              <span className="text-gradient-bright">can&apos;t betray you</span>
+              Build where breaches{" "}
+              <span className="text-gradient-bright">come up empty</span>
             </h2>
             <p className="mx-auto mt-4 max-w-xl text-base text-slate-300 sm:text-lg">
-              Clone it, audit it, deploy it on your own AWS — all open source. Star the repo to
-              follow along as the managed cloud takes shape.
+              Clone it, read every line, and deploy it into your own AWS account — it&apos;s all open
+              source. Star the repo to follow along as the managed cloud takes shape.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-4">
               <a

--- a/apps/landing/src/components/HeroSection.tsx
+++ b/apps/landing/src/components/HeroSection.tsx
@@ -40,14 +40,14 @@ const HeroSection: React.FC = () => {
 
           <h1 className="animate-fade-up mt-6 text-4xl font-extrabold leading-[1.05] tracking-tight sm:text-5xl md:text-6xl lg:text-7xl">
             <span className="text-fg">The database that</span>
-            <span className="text-gradient animate-gradient block">can&apos;t be breached</span>
+            <span className="text-gradient animate-gradient block">can&apos;t read your data</span>
           </h1>
 
           <p className="animate-fade-up mx-auto mt-6 max-w-2xl text-base text-muted sm:text-lg md:text-xl">
-            Gardbase is an open-source, zero-trust encrypted NoSQL database. Data is encrypted
-            client-side and keys live inside hardware-isolated AWS Nitro Enclaves — so the backend
-            never sees plaintext. Catastrophic breaches become{" "}
-            <strong className="text-fg">architecturally impossible</strong>.
+            Gardbase is an open-source, zero-trust NoSQL database. Records are encrypted inside your
+            own application, and the keys exist only within hardware-isolated AWS Nitro Enclaves — so
+            the server stores ciphertext and nothing else. A breach walks away with{" "}
+            <strong className="text-fg">data it can never decrypt</strong>.
           </p>
 
           <div className="animate-fade-up mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-4">

--- a/apps/landing/src/components/ProblemStatementSection.tsx
+++ b/apps/landing/src/components/ProblemStatementSection.tsx
@@ -21,15 +21,15 @@ const ProblemStatementSection: React.FC = () => {
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="mx-auto mb-14 max-w-3xl text-center sm:mb-16">
           <span className="text-sm font-semibold uppercase tracking-widest text-accent-2">
-            The purpose
+            Why Gardbase
           </span>
           <h2 className="mt-3 text-3xl font-bold tracking-tight text-fg sm:text-4xl md:text-5xl">
-            Encryption shouldn&apos;t be an afterthought
+            Your database is your biggest blast radius
           </h2>
           <p className="mx-auto mt-4 max-w-2xl text-base text-muted sm:text-lg">
-            Most databases are built to read your data. Gardbase is built so it never can. The
-            difference is architectural — and it&apos;s why the entire engine is open source for you
-            to audit.
+            One leaked credential or one misconfigured bucket, and a traditional database hands over
+            everything in plaintext. Gardbase is built so there&apos;s nothing readable to take — and
+            the entire engine is open source for you to audit.
           </p>
         </div>
 


### PR DESCRIPTION
- Soften the hero and CTA absolutes ("can't be breached" / "can't betray you") into architectural truths an engineer can't poke holes in: "can't read your data" and "breaches come up empty"
- Reframe the hero body and problem section around breach blast radius — a breach walks away with data it can never decrypt
- Tighten the CTA and problem-statement copy for credibility with a security-savvy audience